### PR TITLE
feat: defaults tag now consider number 0 or NaN as "empty" value

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ A value is considered empty if it is:
 - An empty string `''`
 - An empty array `[]`
 - An empty object `{}`
+- A number that is either `0` or `NaN`
 
 When the default value is used, the separator (i.e. the `/` character)
 is removed from the string.

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -26,6 +26,9 @@ const RE = /^(\s*)(\/)([a-zA-Z0-9]+)(\s*)/;
 const is_empty = x =>
       x === null
   ||  x === undefined
+  ||  (   typeof x === 'number'
+      &&  !x
+      )
   ||  (   (   typeof x === 'string'
           ||  Array.isArray(x)
           )
@@ -62,6 +65,7 @@ const remove_default = str =>
  * - An empty string `''`
  * - An empty array `[]`
  * - An empty object `{}`
+ * - A number that is either `0` or `NaN`
  *
  * When the default value is used, the separator (i.e. the `/` character)
  * is removed from the string.

--- a/test.js
+++ b/test.js
@@ -39,7 +39,7 @@ test('defaults: replace empty values', t => {
 
   t.is
     ( defaults`foo=${foo}/aaa, bar=${bar}/bbb`
-    , 'foo=false, bar=0'
+    , 'foo=false, bar=bbb'
     );
 });
 


### PR DESCRIPTION
it is wrong to consider 0 as an empty value for a number in general
but in the context of the defaults tag it would make sense to relax
this principle.

defaults`Hey ${name} you have ${num}/no new emails`

you probably want for name="John" and num=0

"Hey John you have no new emails"

instead of

"Hey John you have 0 new emails"

BREAKING CHANGE:

it is now impossible to have a default value for an
interpolated number equals to 0 or NaN.